### PR TITLE
Add links to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,8 @@ License: GPL-3
 VignetteBuilder: knitr
 Encoding: UTF-8
 LazyData: true
+URL: https://github.com/wallaceEcoMod/changeRangeR
+BugReports: https://github.com/wallaceEcoMod/changeRangeR/issues
 Depends:
     R (>= 4.0)
 Imports: 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # changeRangeR
 R package for calculating metrics of species distributions
 
-To install this development version, use: devtools::install_github('walllaceEcoMod/changeRangeR')
+To install this development version, use: `devtools::install_github('wallaceEcoMod/changeRangeR')`
 
 Please note that demo data used in the vignettes are available for download at <a href= "https://github.com/wallaceEcoMod/changeRangeR/tree/master/inst/extdata/DemoData" target="_blank">Demo Data</a>.
 


### PR DESCRIPTION
For online package documentation, you may consider using a pkgdown site.

Locally, you can run `usethis::use_pkgdown_github_pages()` to initialize and it will update automatically via GitHub actions!

Happy to provide more guidance.